### PR TITLE
Feat/handle idle players

### DIFF
--- a/public/game.html
+++ b/public/game.html
@@ -145,6 +145,7 @@
               break;
             case "removePlayer":
               if (this.playerInstances[event.playerId]) {
+                this.declareDisconnected(this.playerInstances[event.playerId].name);
                 console.log(`removing ${event.playerId} for inactivity`);
                 this.playerInstances[event.playerId].destroy();
                 delete this.playerInstances[event.playerId];
@@ -318,6 +319,15 @@
         });
         this.physics.world.enableBody(text);
         this.physics.moveTo(text, xPos, -20);
+      }
+
+      declareDisconnected(name) {
+        const text = this.add.text(200, 250, `${name} disconnected for inactivity 😴`, {
+          fontSize: '20px',
+          color: '#000',
+        });
+        this.physics.world.enableBody(text);
+        this.physics.moveTo(text, 200, -20);
       }
     }
 

--- a/public/game.html
+++ b/public/game.html
@@ -145,6 +145,8 @@
               break;
             case "removePlayer":
               if (this.playerInstances[event.playerId]) {
+                console.log(`removing ${event.playerId} for inactivity`);
+                this.playerInstances[event.playerId].destroy();
                 delete this.playerInstances[event.playerId];
               }
               break;

--- a/server/index.js
+++ b/server/index.js
@@ -279,7 +279,7 @@ wss.on('connection', (ws) => {
           gameState.playersRemaining = Object.entries(gameState.players).length;
 
           // start the playerDisconnect checks again
-          playerDisconnectTick();
+          playerDisconnectTimeout = setTimeout(playerDisconnectTick, PLAYER_IDLE_LIMIT_MS);
 
           console.log(gameState);
           break;
@@ -305,4 +305,4 @@ const viewRefreshTick = () => {
 };
 
 viewRefreshTick();
-playerDisconnectTick();
+playerDisconnectTimeout = setTimeout(playerDisconnectTick, PLAYER_IDLE_LIMIT_MS);


### PR DESCRIPTION
adds a 10s tick to check for players that haven't sent movement messages up to the server in the last 10s.

works w/ end game logic + does NOT run during the intermission (so players don't get removed for being idle while waiting for the next game)

shows a little indication on the game view that the player was disconnected for being idle

also moves the view refresh tick _outside_ of the WS connection handler, so we don't send exponential amounts of messages to the view client